### PR TITLE
replace exit with verify

### DIFF
--- a/src/EOFeedRegistry.sol
+++ b/src/EOFeedRegistry.sol
@@ -72,7 +72,7 @@ contract EOFeedRegistry is Initializable, OwnableUpgradeable, IEOFeedRegistry {
         external
         onlyWhitelisted
     {
-        bytes memory data = _feedVerifier.submitAndExit(input, checkpointMetadata, checkpoint, signature, bitmap);
+        bytes memory data = _feedVerifier.submitAndVerify(input, checkpointMetadata, checkpoint, signature, bitmap);
         _processVerifiedRate(data);
     }
 
@@ -97,7 +97,7 @@ contract EOFeedRegistry is Initializable, OwnableUpgradeable, IEOFeedRegistry {
         require(inputs.length > 0, "MISSING_INPUTS");
 
         bytes[] memory data =
-            _feedVerifier.submitAndBatchExit(inputs, checkpointMetadata, checkpoint, signature, bitmap);
+            _feedVerifier.submitAndBatchVerify(inputs, checkpointMetadata, checkpoint, signature, bitmap);
         for (uint256 i = 0; i < data.length; i++) {
             _processVerifiedRate(data[i]);
         }

--- a/src/interfaces/IEOFeedVerifier.sol
+++ b/src/interfaces/IEOFeedVerifier.sol
@@ -17,11 +17,12 @@ interface IEOFeedVerifier {
     }
 
     event ExitProcessed(uint256 indexed id, bool indexed success, bytes returnData);
-
+    event LeafVerified(uint256 indexed id, bytes returnData);
     /**
      * @notice Perform an exit (verify) for one event
      * @param input Exit leaf input
      */
+
     function exit(LeafInput calldata input) external;
 
     /**
@@ -32,7 +33,7 @@ interface IEOFeedVerifier {
      * @param signature Aggregated signature of the checkpoint
      * @param bitmap Bitmap of the validators who signed the checkpoint
      */
-    function submitAndExit(
+    function submitAndVerify(
         LeafInput memory input,
         ICheckpointManager.CheckpointMetadata calldata checkpointMetadata,
         ICheckpointManager.Checkpoint calldata checkpoint,
@@ -50,7 +51,7 @@ interface IEOFeedVerifier {
      * @param signature Aggregated signature of the checkpoint
      * @param bitmap Bitmap of the validators who signed the checkpoint
      */
-    function submitAndBatchExit(
+    function submitAndBatchVerify(
         LeafInput[] memory inputs,
         ICheckpointManager.CheckpointMetadata calldata checkpointMetadata,
         ICheckpointManager.Checkpoint calldata checkpoint,

--- a/test/unit/EOFeedVerifier.t.sol
+++ b/test/unit/EOFeedVerifier.t.sol
@@ -136,7 +136,7 @@ contract EOFeedVerifierExit is InitializedFeedVerifier {
         assertEq(feedVerifier.isProcessedExit(id), true);
     }
 
-    function test_SubmitAndExit() public {
+    function test_submitAndVerify() public {
         IEOFeedVerifier.LeafInput memory input = IEOFeedVerifier.LeafInput({
             unhashedLeaf: unhashedLeaves[0],
             leafIndex: 0,
@@ -158,24 +158,22 @@ contract EOFeedVerifierExit is InitializedFeedVerifier {
 
         (uint256 id,,, bytes memory data) = abi.decode(input.unhashedLeaf, (uint256, address, address, bytes));
         vm.expectEmit(true, true, true, true);
-        emit ExitProcessed(id, true, data);
-        bytes memory leafData = feedVerifier.submitAndExit(input, checkpointMetadata, checkpoint, signature, bitmap);
+        emit LeafVerified(id, data);
+        bytes memory leafData = feedVerifier.submitAndVerify(input, checkpointMetadata, checkpoint, signature, bitmap);
         assertEq(leafData, data);
 
         assertEq(checkpointManager.getEventRootByBlock(blockNumber), hashes[0]);
         assertEq(checkpointManager.checkpointBlockNumbers(0), blockNumber);
 
         assertEq(
-            checkpointManager.getEventMembershipByBlockNumber(
-                blockNumber, leavesArray[0][input.leafIndex], input.leafIndex, input.proof
+            checkpointManager.checkEventMembership(
+                checkpoint.eventRoot, leavesArray[0][input.leafIndex], input.leafIndex, input.proof
             ),
             true
         );
-
-        assertEq(feedVerifier.isProcessedExit(id), true);
     }
 
-    function test_SubmitAndExitRevertsIfDataIsAltered() public {
+    function test_submitAndVerifyRevertsIfDataIsAltered() public {
         IEOFeedVerifier.LeafInput memory input = IEOFeedVerifier.LeafInput({
             unhashedLeaf: unhashedLeaves[0],
             leafIndex: 0,
@@ -195,10 +193,10 @@ contract EOFeedVerifierExit is InitializedFeedVerifier {
         ICheckpointManager.Checkpoint memory checkpoint =
             ICheckpointManager.Checkpoint({ epoch: 1, blockNumber: 1, eventRoot: hashes[0] });
         vm.expectRevert("INVALID_PROOF");
-        feedVerifier.submitAndExit(input, checkpointMetadata, checkpoint, signature, bitmap);
+        feedVerifier.submitAndVerify(input, checkpointMetadata, checkpoint, signature, bitmap);
     }
 
-    function test_SubmitAndBatchExit() public {
+    function test_submitAndBatchVerify() public {
         IEOFeedVerifier.LeafInput[] memory inputs = new IEOFeedVerifier.LeafInput[](1);
         ICheckpointManager.CheckpointMetadata memory checkpointMetadata = ICheckpointManager.CheckpointMetadata({
             blockHash: hashes[1],
@@ -219,21 +217,19 @@ contract EOFeedVerifierExit is InitializedFeedVerifier {
         // solhint-disable-next-line func-named-parameters
 
         vm.expectEmit(true, true, true, true);
-        emit ExitProcessed(id, true, data);
-        feedVerifier.submitAndBatchExit(inputs, checkpointMetadata, checkpoint, signature, bitmaps[0]);
+        emit LeafVerified(id, data);
+        feedVerifier.submitAndBatchVerify(inputs, checkpointMetadata, checkpoint, signature, bitmaps[0]);
 
         assertEq(checkpointManager.getEventRootByBlock(checkpoint.blockNumber), hashes[0]);
         assertEq(checkpointManager.checkpointBlockNumbers(0), checkpoint.blockNumber);
 
         // using leavesArray[1] because [0] holds only one real leaf and 3 mock hashes
         assertEq(
-            checkpointManager.getEventMembershipByBlockNumber(
-                checkpoint.blockNumber, leavesArray[0][inputs[0].leafIndex], inputs[0].leafIndex, inputs[0].proof
+            checkpointManager.checkEventMembership(
+                checkpoint.eventRoot, leavesArray[0][inputs[0].leafIndex], inputs[0].leafIndex, inputs[0].proof
             ),
             true
         );
-
-        assertEq(feedVerifier.isProcessedExit(id), true);
     }
 }
 

--- a/test/unit/EOFeedVerifierBase.t.sol
+++ b/test/unit/EOFeedVerifierBase.t.sol
@@ -48,6 +48,7 @@ abstract contract UninitializedFeedVerifier is Test, Utils {
     bytes32[][] public leavesArray;
 
     event ExitProcessed(uint256 indexed id, bool indexed success, bytes returnData);
+    event LeafVerified(uint256 indexed id, bytes returnData);
 
     function setUp() public virtual {
         bls = new BLS();


### PR DESCRIPTION
we do not want to go through the full exit flow on target nets.
The previous POC implementation had a hack to bypass the checkpoint lookup in the checkpoint manager and this is a cleaner solution.

Next things to do:
1. retire all the exit functions and logic.
2. retire checkpoint manager checkpoint storage as we are not using it for lookups. this will also reduce gas costs
3. I would consolidate the checkpoint and leaves verification into one class. the logic we use in TargetCheckpointManager can easily be integrated directly in the verifier.