### PR TITLE
17000/100-local deploy Update targetContractSetConfig.json

### DIFF
--- a/script/config/17000/100/targetContractSetConfig.json
+++ b/script/config/17000/100/targetContractSetConfig.json
@@ -381,6 +381,6 @@
       "decimals": 18,
       "description": "mETH/ETH",
       "feedId": 53
-    },
+    }
   ]
 }


### PR DESCRIPTION
added support (on target chain 100 which is local deploy) for symbol ids 43- through 53 which are the new strategies.